### PR TITLE
Add support to nest tests

### DIFF
--- a/hostingcheck/Hostingcheck/Lib/Results/Tests.php
+++ b/hostingcheck/Hostingcheck/Lib/Results/Tests.php
@@ -38,6 +38,18 @@ class Hostingcheck_Results_Tests extends Hostingcheck_Collection_Abstract
     }
 
     /**
+     * Add multiple test results at once by passing them in a
+     * Hostingcheck_Results_Tests collection.
+     *
+     * @param Hostingcheck_Results_Tests $tests
+     */
+    public function addMultiple(Hostingcheck_Results_Tests $tests) {
+        foreach ($tests as $test) {
+            $this->add($test);
+        }
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return Hostingcheck_Results_Test

--- a/hostingcheck/Hostingcheck/Lib/Runner/Test.php
+++ b/hostingcheck/Hostingcheck/Lib/Runner/Test.php
@@ -37,9 +37,29 @@ class Hostingcheck_Runner_Test
     /**
      * Run the test.
      *
-     * @return Hostingcheck_Results_Test
+     * @return Hostingcheck_Results_Tests
+     *     A collection with the result of its own and optional sub tests.
      */
     public function run()
+    {
+        $result = new Hostingcheck_Results_Tests();
+
+        // Validate the test first.
+        $testResult = $this->runTest();
+        $result->add($testResult);
+
+        // Run the sub tests.
+        $result->addMultiple($this->runTests($testResult));
+
+        return $result;
+    }
+
+    /**
+     * Run a single test.
+     *
+     * @return Hostingcheck_Results_Test
+     */
+    protected function runTest()
     {
         $info = $this->scenario->info();
         $result = new Hostingcheck_Result_Info();
@@ -61,5 +81,34 @@ class Hostingcheck_Runner_Test
         );
 
         return $testResult;
+    }
+
+    /**
+     * Run all the sub tests.
+     *
+     * Will only be run if the given result is
+     * - supported
+     * - not a failure
+     *
+     * @param Hostingcheck_Results_Test $testResult
+     *     The single test result.
+     *
+     * @return Hostingcheck_Results_Tests
+     */
+    protected function runTests(Hostingcheck_Results_Test $testResult)
+    {
+        // Run the sub tests only if the test is valid.
+        if (
+            !($testResult->info()->getValue() instanceof Hostingcheck_Value_NotSupported)
+            && !($testResult->result() instanceof Hostingcheck_Result_Failure)
+        ) {
+            $testsRunner = new Hostingcheck_Runner_Tests($this->scenario->tests());
+            $result = $testsRunner->run();
+        }
+        else {
+            $result = new Hostingcheck_Results_Tests();
+        }
+
+        return $result;
     }
 }

--- a/hostingcheck/Hostingcheck/Lib/Runner/Tests.php
+++ b/hostingcheck/Hostingcheck/Lib/Runner/Tests.php
@@ -13,12 +13,12 @@
  *
  * @author Peter Decuyper <peter@serial-graphics.be>
  */
-class Hostingcheck_Runner_Group
+class Hostingcheck_Runner_Tests
 {
     /**
      * The scenario to use in the test runner.
      *
-     * @var Hostingcheck_Scenario_Group
+     * @var Hostingcheck_Scenario_Tests
      */
     protected $scenario;
 
@@ -26,10 +26,10 @@ class Hostingcheck_Runner_Group
     /**
      * Constructor.
      *
-     * @param Hostingcheck_Scenario_Group $scenario
-     *     The scenario for the group.
+     * @param Hostingcheck_Scenario_Tests $scenario
+     *     The scenario for the tests.
      */
-    public function __construct(Hostingcheck_Scenario_Group $scenario)
+    public function __construct(Hostingcheck_Scenario_Tests $scenario)
     {
         $this->scenario = $scenario;
     }
@@ -37,14 +37,16 @@ class Hostingcheck_Runner_Group
     /**
      * Run the test.
      *
-     * @return Hostingcheck_Results_Group
+     * @return Hostingcheck_Results_Tests
      */
     public function run()
     {
-        $result = new Hostingcheck_Results_Group($this->scenario);
+        $result = new Hostingcheck_Results_Tests($this->scenario);
 
-        $testsRunner = new Hostingcheck_Runner_Tests($this->scenario->tests());
-        $result->tests()->addMultiple($testsRunner->run());
+        foreach ($this->scenario as $testScenario) {
+            $testRunner = new Hostingcheck_Runner_Test($testScenario);
+            $result->addMultiple($testRunner->run());
+        }
 
         return $result;
     }

--- a/hostingcheck/Hostingcheck/Lib/Runner/Tests.php
+++ b/hostingcheck/Hostingcheck/Lib/Runner/Tests.php
@@ -41,7 +41,7 @@ class Hostingcheck_Runner_Tests
      */
     public function run()
     {
-        $result = new Hostingcheck_Results_Tests($this->scenario);
+        $result = new Hostingcheck_Results_Tests();
 
         foreach ($this->scenario as $testScenario) {
             $testRunner = new Hostingcheck_Runner_Test($testScenario);

--- a/hostingcheck/Hostingcheck/Lib/Scenario/Test.php
+++ b/hostingcheck/Hostingcheck/Lib/Scenario/Test.php
@@ -36,6 +36,14 @@ class Hostingcheck_Scenario_Test
      */
     protected $validators;
 
+    /**
+     * Optional set of nested tests that will only run if the parent test is
+     * not failed.
+     *
+     * @var Hostingcheck_Scenario_Tests
+     */
+    protected $tests;
+
 
     /**
      * Class constructor.
@@ -44,18 +52,23 @@ class Hostingcheck_Scenario_Test
      *     The human title for the test.
      * @param Hostingcheck_Info_Interface $info
      *     The info object.
-     * @param Hostingcheck_Scenario_Validators
+     * @param Hostingcheck_Scenario_Validators $validators
      *     The validators to use in the test.
+     * @param Hostingcheck_Scenario_Tests $tests
+     *     A test can have a nested set of tests.
+     *     These tests are only run if this test is failed.
      */
     public function __construct(
         $title,
         Hostingcheck_Info_Interface $info,
-        Hostingcheck_Scenario_Validators $validators
+        Hostingcheck_Scenario_Validators $validators,
+        Hostingcheck_Scenario_Tests $tests
     )
     {
         $this->title = $title;
         $this->info = $info;
         $this->validators = $validators;
+        $this->tests = $tests;
     }
 
     /**
@@ -86,5 +99,15 @@ class Hostingcheck_Scenario_Test
     public function validators()
     {
         return $this->validators;
+    }
+
+    /**
+     * Get the tests that are nested within the test.
+     *
+     * @return Hostingcheck_Scenario_Tests
+     */
+    public function tests()
+    {
+        return $this->tests;
     }
 }

--- a/hostingcheck/Hostingcheck/example.scenario.php
+++ b/hostingcheck/Hostingcheck/example.scenario.php
@@ -120,6 +120,32 @@ $php[] = array(
     'required'   => true,
 );
 $php[] = array(
+    'title'      => 'Extension : Date',
+    'info'       => 'Check_PHP_Info_Extension',
+    'info args'  => array('name' => 'date'),
+    'validators' => array(
+        array(
+            'validator'       => 'Hostingcheck_Validate_NotEmpty',
+        ),
+    ),
+    'required'   => true,
+    'tests' => array(
+        array(
+            'title'      => 'Timezone',
+            'info'       => 'Check_PHP_Info_Config',
+            'info args'  => array(
+                'name' => 'date.timezone',
+            ),
+            'validators' => array(
+                array(
+                    'validator' => 'Hostingcheck_Validate_Compare',
+                    'args'      => array('equal', 'Antarctica/Troll'),
+                ),
+            ),
+        ),
+    )
+);
+$php[] = array(
     'title'      => 'Extension : JSON',
     'info'       => 'Check_PHP_Info_Extension',
     'info args'  => array('name' => 'json'),
@@ -140,6 +166,15 @@ $php[] = array(
         ),
     ),
     'required'   => true,
+    'tests' => array(
+        array(
+            'title' => 'FooBar fake value test',
+            'info'  => 'Check_PHP_Info_Config',
+            'info args' => array(
+                'name' => 'foobar.bizbaz',
+            ),
+        )
+    )
 );
 $php[] = array(
     'title'      => 'Memory limit',

--- a/tests/Hostingcheck/Lib/Results/TestTest.php
+++ b/tests/Hostingcheck/Lib/Results/TestTest.php
@@ -23,7 +23,8 @@ class Hostingcheck_Results_Test_TestCase extends PHPUnit_Framework_TestCase
         $scenario = new Hostingcheck_Scenario_Test(
             'test',
             new Hostingcheck_Info_Text(array('text' => 'Scenario Test')),
-            new Hostingcheck_Scenario_Validators()
+            new Hostingcheck_Scenario_Validators(),
+            new Hostingcheck_Scenario_Tests()
         );
         $info = new Hostingcheck_Info_Text(array('text' => 'Test info'));
         $result = new Hostingcheck_Result_Info();

--- a/tests/Hostingcheck/Lib/Results/TestsTest.php
+++ b/tests/Hostingcheck/Lib/Results/TestsTest.php
@@ -38,6 +38,22 @@ class Hostingcheck_Results_Tests_TestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test adding a collection of tests.
+     */
+    public function testAddMultiple()
+    {
+        $tests = new Hostingcheck_Results_Tests();
+
+        $multiple = new Hostingcheck_Results_Tests();
+        $multiple->add($this->createTestResult());
+        $multiple->add($this->createTestResult());
+        $multiple->add($this->createTestResult());
+
+        $tests->addMultiple($multiple);
+        $this->assertCount(3, $multiple);
+    }
+
+    /**
      * Test the iterator functionality.
      */
     public function testSeekable()

--- a/tests/Hostingcheck/Lib/Results/TestsTest.php
+++ b/tests/Hostingcheck/Lib/Results/TestsTest.php
@@ -137,7 +137,8 @@ class Hostingcheck_Results_Tests_TestCase extends PHPUnit_Framework_TestCase
         $scenario = new Hostingcheck_Scenario_Test(
             $name,
             new Hostingcheck_Info_Text(),
-            new Hostingcheck_Scenario_Validators()
+            new Hostingcheck_Scenario_Validators(),
+            new Hostingcheck_Scenario_Tests()
         );
 
         switch ($resultType) {

--- a/tests/Hostingcheck/Lib/ResultsTest.php
+++ b/tests/Hostingcheck/Lib/ResultsTest.php
@@ -148,7 +148,8 @@ class Hostingcheck_Results_TestCase extends PHPUnit_Framework_TestCase
         $scenario = new Hostingcheck_Scenario_Test(
             $name,
             new Hostingcheck_Info_Text(),
-            new Hostingcheck_Scenario_Validators()
+            new Hostingcheck_Scenario_Validators(),
+            new Hostingcheck_Scenario_Tests()
         );
 
         switch ($resultType) {

--- a/tests/Hostingcheck/Lib/Runner/GroupTest.php
+++ b/tests/Hostingcheck/Lib/Runner/GroupTest.php
@@ -24,12 +24,14 @@ class Hostingcheck_Runner_Group_TestCase extends PHPUnit_Framework_TestCase
         $tests->add(new Hostingcheck_Scenario_Test(
             'Info text',
             new Hostingcheck_Info_Text(),
-            new Hostingcheck_Scenario_Validators()
+            new Hostingcheck_Scenario_Validators(),
+            new Hostingcheck_Scenario_Tests()
         ));
         $tests->add(new Hostingcheck_Scenario_Test(
             'Report Date',
             new Hostingcheck_Info_DateTime(),
-            new Hostingcheck_Scenario_Validators()
+            new Hostingcheck_Scenario_Validators(),
+            new Hostingcheck_Scenario_Tests()
         ));
 
         $scenario = new Hostingcheck_Scenario_Group('group1', 'Group 1', $tests);

--- a/tests/Hostingcheck/Lib/Runner/TestTest.php
+++ b/tests/Hostingcheck/Lib/Runner/TestTest.php
@@ -23,7 +23,8 @@ class Hostingcheck_Runner_Test_TestCase extends PHPUnit_Framework_TestCase
         $scenario = new Hostingcheck_Scenario_Test(
             'Test info',
             new Hostingcheck_Info_Text(array('text' => 'Test text info')),
-            new Hostingcheck_Scenario_Validators()
+            new Hostingcheck_Scenario_Validators(),
+            new Hostingcheck_Scenario_Tests()
         );
 
         $runner = new Hostingcheck_Runner_Test($scenario);
@@ -44,7 +45,8 @@ class Hostingcheck_Runner_Test_TestCase extends PHPUnit_Framework_TestCase
         $scenario = new Hostingcheck_Scenario_Test(
             'Test info',
             new Hostingcheck_Info_Text(array('text' => 2)),
-            $validators
+            $validators,
+            new Hostingcheck_Scenario_Tests()
         );
 
         $runner = new Hostingcheck_Runner_Test($scenario);
@@ -65,7 +67,8 @@ class Hostingcheck_Runner_Test_TestCase extends PHPUnit_Framework_TestCase
         $scenario = new Hostingcheck_Scenario_Test(
             'Test info',
             new Hostingcheck_Info_Text(),
-            $validators
+            $validators,
+            new Hostingcheck_Scenario_Tests()
         );
 
         $runner = new Hostingcheck_Runner_Test($scenario);

--- a/tests/Hostingcheck/Lib/Runner/TestTest.php
+++ b/tests/Hostingcheck/Lib/Runner/TestTest.php
@@ -29,9 +29,12 @@ class Hostingcheck_Runner_Test_TestCase extends PHPUnit_Framework_TestCase
 
         $runner = new Hostingcheck_Runner_Test($scenario);
         $result = $runner->run();
-        $this->assertInstanceOf('Hostingcheck_Results_Test', $result);
-        $this->assertInstanceOf('Hostingcheck_Info_Text', $result->info());
-        $this->assertInstanceOf('Hostingcheck_Result_Info', $result->result());
+        $this->assertInstanceOf('Hostingcheck_Results_Tests', $result);
+
+        $testResult = $result->current();
+        $this->assertInstanceOf('Hostingcheck_Results_Test', $testResult);
+        $this->assertInstanceOf('Hostingcheck_Info_Text', $testResult->info());
+        $this->assertInstanceOf('Hostingcheck_Result_Info', $testResult->result());
     }
 
     /**
@@ -50,7 +53,7 @@ class Hostingcheck_Runner_Test_TestCase extends PHPUnit_Framework_TestCase
         );
 
         $runner = new Hostingcheck_Runner_Test($scenario);
-        $result = $runner->run();
+        $result = $runner->run()->current();
         $this->assertInstanceOf('Hostingcheck_Results_Test', $result);
         $this->assertInstanceOf('Hostingcheck_Info_Text', $result->info());
         $this->assertInstanceOf('Hostingcheck_Result_Success', $result->result());
@@ -72,9 +75,100 @@ class Hostingcheck_Runner_Test_TestCase extends PHPUnit_Framework_TestCase
         );
 
         $runner = new Hostingcheck_Runner_Test($scenario);
-        $result = $runner->run();
+        $result = $runner->run()->current();
         $this->assertInstanceOf('Hostingcheck_Results_Test', $result);
         $this->assertInstanceOf('Hostingcheck_Info_Text', $result->info());
         $this->assertInstanceOf('Hostingcheck_Result_Failure', $result->result());
+    }
+
+    /**
+     * Test running the test scenario with sub tests but with unsupported info.
+     *
+     * The sub tests should not run when the test info value is Not Supported.
+     */
+    public function testRunWithInfoNotSupported()
+    {
+        // Create a Info Text mock object that has a NotSupported value.
+        $info = $this->getMockBuilder('Hostingcheck_Info_Text')
+                     ->getMock();
+        // Configure the stub.
+        $info->method('getValue')
+             ->willReturn(new Hostingcheck_Value_NotSupported());
+
+        // Create the sub tests.
+        $subTests = new Hostingcheck_Scenario_Tests();
+        $subTests->add(new Hostingcheck_Scenario_Test(
+            'Test sub test',
+            new Hostingcheck_Info_Text(),
+            new Hostingcheck_Scenario_Validators(),
+            new Hostingcheck_Scenario_Tests()
+        ));
+
+        // Create the scenario.
+        $scenario = new Hostingcheck_Scenario_Test(
+            'Test info',
+            $info,
+            new Hostingcheck_Scenario_Validators(),
+            $subTests
+        );
+
+        $runner = new Hostingcheck_Runner_Test($scenario);
+        $result = $runner->run();
+        $this->assertCount(1, $result);
+    }
+
+    /**
+     * Test running the test scenario with sub tests with invalid validators.
+     *
+     * The sub tests should not run when the test result is not success full.
+     */
+    public function testRunWithInvalidValidators()
+    {
+        $subTests = new Hostingcheck_Scenario_Tests();
+        $subTests->add(new Hostingcheck_Scenario_Test(
+            'Test sub test',
+            new Hostingcheck_Info_Text(),
+            new Hostingcheck_Scenario_Validators(),
+            new Hostingcheck_Scenario_Tests()
+        ));
+
+        $validators = new Hostingcheck_Scenario_Validators();
+        $validators->add(new Hostingcheck_Validate_NotEmpty());
+
+        $scenario = new Hostingcheck_Scenario_Test(
+            'Test info',
+            new Hostingcheck_Info_Text(),
+            $validators,
+            $subTests
+        );
+
+        $runner = new Hostingcheck_Runner_Test($scenario);
+        $result = $runner->run();
+        $this->assertCount(1, $result);
+    }
+
+    /**
+     * Test run with sub tests.
+     */
+    public function testRunWithSubTests()
+    {
+        $subTests = new Hostingcheck_Scenario_Tests();
+        $subTests->add(new Hostingcheck_Scenario_Test(
+            'Test sub test',
+            new Hostingcheck_Info_Text(),
+            new Hostingcheck_Scenario_Validators(),
+            new Hostingcheck_Scenario_Tests()
+        ));
+
+        $scenario = new Hostingcheck_Scenario_Test(
+            'Test info',
+            new Hostingcheck_Info_Text(array('text' => 'Test text info')),
+            new Hostingcheck_Scenario_Validators(),
+            $subTests
+        );
+
+        $runner = new Hostingcheck_Runner_Test($scenario);
+        $result = $runner->run();
+        $this->assertCount(2, $result);
     }
 }

--- a/tests/Hostingcheck/Lib/Runner/TestsTest.php
+++ b/tests/Hostingcheck/Lib/Runner/TestsTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Hostingcheck (https://github.com/zero2one/hostingcheck)
+ *
+ * @link      https://github.com/zero2one/hostingcheck source repository.
+ * @copyright Copyright (c) 2005-2014 Serial Graphics. (http://serial-graphics.be)
+ * @license   http://opensource.org/licenses/GPL-2.0 GNU Public License
+ */
+
+
+/**
+ * Tests for Hostingcheck_Runner_Test class.
+ *
+ * @author Peter Decuyper <peter@serial-graphics.be>
+ */
+class Hostingcheck_Runner_Tests_TestCase extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test the run method.
+     */
+    public function testRun()
+    {
+        $scenario = new Hostingcheck_Scenario_Tests();
+        $scenario->add(new Hostingcheck_Scenario_Test(
+            'Info text',
+            new Hostingcheck_Info_Text(),
+            new Hostingcheck_Scenario_Validators(),
+            new Hostingcheck_Scenario_Tests()
+        ));
+        $scenario->add(new Hostingcheck_Scenario_Test(
+            'Report Date',
+            new Hostingcheck_Info_DateTime(),
+            new Hostingcheck_Scenario_Validators(),
+            new Hostingcheck_Scenario_Tests()
+        ));
+
+        $runner = new Hostingcheck_Runner_Tests($scenario);
+
+        $result = $runner->run();
+        $this->assertInstanceOf('Hostingcheck_Results_Tests', $result);
+        $this->assertCount(2, $result);
+    }
+}

--- a/tests/Hostingcheck/Lib/Scenario/ParserTest.php
+++ b/tests/Hostingcheck/Lib/Scenario/ParserTest.php
@@ -66,6 +66,8 @@ class Hostingcheck_Scenario_Parser_TestCase extends PHPUnit_Framework_TestCase
             'Hostingcheck_Scenario_Validators',
             $test->validators());
         $this->assertCount(0, $test->validators());
+        $this->assertInstanceOf('Hostingcheck_Scenario_Tests', $test->tests());
+        $this->assertCount(0, $test->tests());
     }
 
     /**
@@ -101,6 +103,78 @@ class Hostingcheck_Scenario_Parser_TestCase extends PHPUnit_Framework_TestCase
             'Hostingcheck_Validate_ByteSize',
             $validators->seek(0)
         );
+    }
+
+    /**
+     * Test the test parser with nested tests.
+     */
+    public function testTestParserWithNestedTests()
+    {
+        $parser = new Hostingcheck_Scenario_Parser();
+
+        $config = array(
+            'title' => 'Test parser',
+            'info' => 'Hostingcheck_Info_Text',
+            'tests' => array(
+                array(
+                    'title' => 'subtest 1',
+                    'info' => 'Hostingcheck_Info_Text',
+                ),
+                array(
+                    'title' => 'subtest 2',
+                    'info' => 'Hostingcheck_Info_Text',
+                ),
+            ),
+        );
+
+        $test = $parser->test($config);
+        $this->assertCount(2, $test->tests());
+    }
+
+    /**
+     * Test the tests collection parser without tests set.
+     */
+    public function testTestsParserWithoutTests()
+    {
+        $parser = new Hostingcheck_Scenario_Parser();
+
+        // Tests not in the config.
+        $config = array();
+        $tests = $parser->tests($config);
+        $this->assertInstanceOf('Hostingcheck_Scenario_Tests', $tests);
+        $this->assertCount(0, $tests);
+
+        // Empty tests array.
+        $config = array(
+            'tests' => array()
+        );
+        $tests = $parser->tests($config);
+        $this->assertInstanceOf('Hostingcheck_Scenario_Tests', $tests);
+        $this->assertCount(0, $tests);
+    }
+
+    /**
+     * Test the tests collection parser with tests.
+     */
+    public function testTestsParserWithTests()
+    {
+        $parser = new Hostingcheck_Scenario_Parser();
+
+        $config = array(
+            'tests' => array(
+                array(
+                    'title' => 'subtest 1',
+                    'info' => 'Hostingcheck_Info_Text',
+                ),
+                array(
+                    'title' => 'subtest 2',
+                    'info' => 'Hostingcheck_Info_Text',
+                ),
+            )
+        );
+        $tests = $parser->tests($config);
+        $this->assertInstanceOf('Hostingcheck_Scenario_Tests', $tests);
+        $this->assertCount(2, $tests);
     }
 
     /**

--- a/tests/Hostingcheck/Lib/Scenario/TestTest.php
+++ b/tests/Hostingcheck/Lib/Scenario/TestTest.php
@@ -23,15 +23,18 @@ class Hostingcheck_Scenario_Test_TestCase extends PHPUnit_Framework_TestCase
         $title = 'Info test';
         $info = new Hostingcheck_Info_Text();
         $validators = new Hostingcheck_Scenario_Validators();
+        $tests = new Hostingcheck_Scenario_tests();
 
         $test = new Hostingcheck_Scenario_Test(
             $title,
             $info,
-            $validators
+            $validators,
+            $tests
         );
 
         $this->assertEquals($title, $test->title());
         $this->assertEquals($info, $test->info());
         $this->assertEquals($validators, $test->validators());
+        $this->assertEquals($tests, $test->tests());
     }
 }

--- a/tests/Hostingcheck/Lib/Scenario/TestsTest.php
+++ b/tests/Hostingcheck/Lib/Scenario/TestsTest.php
@@ -94,7 +94,8 @@ class Hostingcheck_Scenario_Tests_TestCase extends PHPUnit_Framework_TestCase
         $test = new Hostingcheck_Scenario_Test(
             $title,
             new Hostingcheck_Info_Text(),
-            new Hostingcheck_Scenario_Validators()
+            new Hostingcheck_Scenario_Validators(),
+            new Hostingcheck_Scenario_Tests()
         );
         return $test;
     }


### PR DESCRIPTION
Add the functionality to add a set of tests to a test.
That set will only run if the parent test passes:
- The collected info value is supported.
- All validators (if any) are valid.
